### PR TITLE
Adjusted string "date" in PackageInfo

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -11,7 +11,7 @@ SetPackageInfo( rec(
 PackageName := "NConvex",
 Subtitle := "A Gap package to perform polyhedral computations",
 Version := "2019.02.02",
-Date := "2019.02.02", # dd/mm/yyyy format
+Date := "02/02/2019", # dd/mm/yyyy format
 
 Persons := [
   rec(


### PR DESCRIPTION
When loading NConvex, the following message appears:

#E  component `Date' must be bound to a string of the form `dd/mm/yyyy'
#E Validation of package nconvex from /home/i/HDD/Computer/Mathematics_software/gap-4.10.0/local/pkg/NConvex failed

This can be avoided, by adjusting the "date" string in the PackageInfo.